### PR TITLE
Updated the url typedata input to have input type 'url'

### DIFF
--- a/urlpicker/app/views/url.picker.html
+++ b/urlpicker/app/views/url.picker.html
@@ -38,7 +38,7 @@
 
 					<div class="tab-body">
 						<div ng-show="picker.type == 'url'">
-							<input type="text" ng-model="picker.typeData.url" localize="placeholder" placeholder="@urlPicker_urlPlaceholder" />
+							<input type="url" ng-model="picker.typeData.url" localize="placeholder" placeholder="@urlPicker_urlPlaceholder" />
 							<a href class="delete-icon url-delete" ng-click="resetType('url', picker)"><i class="icon icon-delete" ng-show="picker.typeData.url"></i></a>
 						</div>
 						<div ng-show="picker.type == 'content'">


### PR DESCRIPTION
A simple change to the angular view to update the input type of the external URL input to be 'url' this adds validation to the URL entered to ensure that the URL is properly formatted and includes either http:// or https:// 

As I am typing this I can foresee this as a breaking change for users that may be using this property to pick a local file not in the media section or using the input to enter something that is not a valid URL. Perhaps a better solution would be to enable this as an option in the picker settings?

Best
L